### PR TITLE
Feature/spacio 55/admin upload a virtual tour

### DIFF
--- a/src/Application/Commands/Concretes/UploadTour360Command.cs
+++ b/src/Application/Commands/Concretes/UploadTour360Command.cs
@@ -27,18 +27,16 @@ public class UploadTour360Command : ICommand<bool>
     public async Task<bool> ExecuteAsync()
     {
         var tourRequest = await _repository.GetByIdAsync(_tourRequestId)
-                          ?? throw new Exception("Solicitud de Tour no encontrada.");
+                          ?? throw new Exception("360 Tour Request Not Found");
 
         if (tourRequest.Status != Domain.Enums.Tour360Status.Pending &&
             tourRequest.Status != Domain.Enums.Tour360Status.Scheduled)
         {
-            throw new Exception("La solicitud no puede ser subida en el estado actual.");
+            throw new Exception("The Request cannot be Uploaded in Current Status");
         }
 
-        // Primero subir el tour
         await _tourUploaderAdapter.UploadTourAsync(tourRequest.EnvironmentId, _tourUpload);
 
-        // Después actualizar el estado
         tourRequest.Status = Domain.Enums.Tour360Status.Completed;
         await _repository.UpdateAsync(tourRequest);
 

--- a/src/Application/Commands/Concretes/UploadTour360Command.cs
+++ b/src/Application/Commands/Concretes/UploadTour360Command.cs
@@ -1,0 +1,47 @@
+using AdminService.Src.Application.Commands.Interfaces;
+using AdminService.Src.Application.DTOs.Create;
+using AdminService.Src.Application.Interfaces;
+using AdminService.Src.Domain.Interfaces;
+
+namespace AdminService.Src.Application.Commands.Concretes;
+
+public class UploadTour360Command : ICommand<bool>
+{
+    private readonly Guid _tourRequestId;
+    private readonly TourUploadDto _tourUpload;
+    private readonly ITour360RequestRepository _repository;
+    private readonly ITourUploaderAdapter _tourUploaderAdapter;
+
+    public UploadTour360Command(
+        Guid tourRequestId,
+        TourUploadDto tourUpload,
+        ITour360RequestRepository repository,
+        ITourUploaderAdapter tourUploaderAdapter)
+    {
+        _tourRequestId = tourRequestId;
+        _tourUpload = tourUpload;
+        _repository = repository;
+        _tourUploaderAdapter = tourUploaderAdapter;
+    }
+
+    public async Task<bool> ExecuteAsync()
+    {
+        var tourRequest = await _repository.GetByIdAsync(_tourRequestId)
+                          ?? throw new Exception("Solicitud de Tour no encontrada.");
+
+        if (tourRequest.Status != Domain.Enums.Tour360Status.Pending &&
+            tourRequest.Status != Domain.Enums.Tour360Status.Scheduled)
+        {
+            throw new Exception("La solicitud no puede ser subida en el estado actual.");
+        }
+
+        // Primero subir el tour
+        await _tourUploaderAdapter.UploadTourAsync(tourRequest.EnvironmentId, _tourUpload);
+
+        // Después actualizar el estado
+        tourRequest.Status = Domain.Enums.Tour360Status.Completed;
+        await _repository.UpdateAsync(tourRequest);
+
+        return true;
+    }
+}

--- a/src/Application/DTOs/Create/POIDto.cs
+++ b/src/Application/DTOs/Create/POIDto.cs
@@ -1,0 +1,10 @@
+namespace AdminService.Src.Application.DTOs.Create;
+
+public class POIDto
+{
+    public string Position { get; set; } = string.Empty;
+
+    public string Text { get; set; } = string.Empty;
+
+    public string SceneId { get; set; } = string.Empty;
+}

--- a/src/Application/DTOs/Create/SceneDto.cs
+++ b/src/Application/DTOs/Create/SceneDto.cs
@@ -1,0 +1,16 @@
+namespace AdminService.Src.Application.DTOs.Create;
+
+public class SceneDto
+{
+    public string Id { get; set; } = string.Empty;
+
+    public string Name { get; set; } = string.Empty;
+
+    public string FileId { get; set; } = string.Empty;
+
+    public string FileName { get; set; } = string.Empty;
+
+    public string FileUrl { get; set; } = string.Empty;
+
+    public List<POIDto> Pois { get; set; } = [];
+}

--- a/src/Application/DTOs/Create/TourUploadDto.cs
+++ b/src/Application/DTOs/Create/TourUploadDto.cs
@@ -1,0 +1,6 @@
+namespace AdminService.Src.Application.DTOs.Create;
+
+public class TourUploadDto
+{
+    public List<SceneDto> Scenes { get; set; } = [];
+}

--- a/src/Application/Interfaces/ITour360RequestService.cs
+++ b/src/Application/Interfaces/ITour360RequestService.cs
@@ -8,4 +8,6 @@ public interface ITour360RequestService
     Task<(List<Tour360RequestDto> Items, int TotalItems)> GetAllAsync(GetTour360RequestsRequest request);
 
     Task<Tour360RequestDto> CreateAsync(Tour360RequestCreateDto request, string authenticatedUserId);
+
+    Task<bool> Upload360TourAsync(Guid tourRequestId, TourUploadDto uploadDto);
 }

--- a/src/Application/Interfaces/ITourUploadAdapter.cs
+++ b/src/Application/Interfaces/ITourUploadAdapter.cs
@@ -1,0 +1,8 @@
+using AdminService.Src.Application.DTOs.Create;
+
+namespace AdminService.Src.Application.Interfaces;
+
+public interface ITourUploaderAdapter
+{
+    Task UploadTourAsync(Guid environmentPublicId, TourUploadDto tourUpload);
+}

--- a/src/Application/Services/Tour360RequestService.cs
+++ b/src/Application/Services/Tour360RequestService.cs
@@ -10,11 +10,14 @@ namespace AdminService.Src.Application.Services;
 public class Tour360RequestService(
     ITour360RequestRepository repository,
     IMapper mapper,
-    IEnvironmentServiceAdapter environmentServiceAdapter) : ITour360RequestService
+    IEnvironmentServiceAdapter environmentServiceAdapter,
+    ITourUploaderAdapter tourUploadAdapter
+    ) : ITour360RequestService
 {
     private readonly ITour360RequestRepository _repository = repository;
     private readonly IMapper _mapper = mapper;
     private readonly IEnvironmentServiceAdapter _environmentServiceAdapter = environmentServiceAdapter;
+    private readonly ITourUploaderAdapter _tourUploadAdapter = tourUploadAdapter;
 
     public async Task<Tour360RequestDto> CreateAsync(Tour360RequestCreateDto request, string authenticatedUserId)
     {
@@ -35,6 +38,17 @@ public class Tour360RequestService(
             _repository,
             _mapper,
             _environmentServiceAdapter);
+
+        return await command.ExecuteAsync();
+    }
+
+    public async Task<bool> Upload360TourAsync(Guid tourRequestId, TourUploadDto uploadDto)
+    {
+        var command = new UploadTour360Command(
+            tourRequestId,
+            uploadDto,
+            _repository,
+            _tourUploadAdapter);
 
         return await command.ExecuteAsync();
     }

--- a/src/Domain/Entities/Tour360Request.cs
+++ b/src/Domain/Entities/Tour360Request.cs
@@ -6,6 +6,8 @@ public class Tour360Request
 {
     public Guid Id { get; set; } = Guid.NewGuid();
 
+    public Guid PublicId { get; set; } = Guid.NewGuid();
+
     public Guid EnvironmentId { get; set; }
 
     public Guid OwnerId { get; set; }

--- a/src/Domain/Interfaces/ITour360RequestInterface.cs
+++ b/src/Domain/Interfaces/ITour360RequestInterface.cs
@@ -8,4 +8,8 @@ public interface ITour360RequestRepository
     Task<(List<Tour360Request> Items, int TotalItems)> GetAllAsync(Tour360Status? status, int page, int limit);
 
     Task<Tour360Request> AddAsync(Tour360Request request);
+
+    Task<Tour360Request?> GetByIdAsync(Guid id);
+
+    Task UpdateAsync(Tour360Request request);
 }

--- a/src/Infraestructure/Adapters/EnvironmentServiceAdapter.cs
+++ b/src/Infraestructure/Adapters/EnvironmentServiceAdapter.cs
@@ -1,7 +1,7 @@
 using AdminService.src.Application.DTOs.Response;
 using AdminService.Src.Application.Interfaces;
 
-namespace AdminService.Src.Infrastructure.Adapters;
+namespace AdminService.Src.Infraestructure.Adapters;
 
 public class EnvironmentServiceAdapter(HttpClient httpClient) : IEnvironmentServiceAdapter
 {

--- a/src/Infraestructure/Adapters/TourUploaderAdapter.cs
+++ b/src/Infraestructure/Adapters/TourUploaderAdapter.cs
@@ -1,0 +1,20 @@
+using AdminService.Src.Application.DTOs.Create;
+using AdminService.Src.Application.Interfaces;
+
+namespace AdminService.Src.Infraestructure.Adapters;
+
+public class TourUploaderAdapter(HttpClient httpClient) : ITourUploaderAdapter
+{
+    private readonly HttpClient _httpClient = httpClient;
+
+    public async Task UploadTourAsync(Guid environmentPublicId, TourUploadDto tourUpload)
+    {
+        var url = $"http://localhost:5150/api/tours?environmentPublicId={environmentPublicId}";
+        var response = await _httpClient.PostAsJsonAsync(url, tourUpload);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            throw new Exception("Error al subir el Tour 360.");
+        }
+    }
+}

--- a/src/Infraestructure/Repositories/Tour360RequestRepository.cs
+++ b/src/Infraestructure/Repositories/Tour360RequestRepository.cs
@@ -36,4 +36,16 @@ public class Tour360RequestRepository(AppDbContext context) : ITour360RequestRep
         await _context.SaveChangesAsync();
         return request;
     }
+
+    public async Task<Tour360Request?> GetByIdAsync(Guid id)
+    {
+        return await _context.Set<Tour360Request>()
+            .FirstOrDefaultAsync(t => t.Id == id);
+    }
+
+    public async Task UpdateAsync(Tour360Request request)
+    {
+        _context.Set<Tour360Request>().Update(request);
+        await _context.SaveChangesAsync();
+    }
 }

--- a/src/WebApi/Controllers/Tour360RequestController.cs
+++ b/src/WebApi/Controllers/Tour360RequestController.cs
@@ -35,4 +35,11 @@ public class Tour360RequestController(ITour360RequestService service) : Controll
         var created = await _service.CreateAsync(request, authenticatedUserId);
         return CreatedAtAction(nameof(Create), new { id = created.EnvironmentId }, created);
     }
+
+    [HttpPost("{id}/upload")]
+    public async Task<IActionResult> UploadTour(Guid id, [FromBody] TourUploadDto uploadDto)
+    {
+        await _service.Upload360TourAsync(id, uploadDto);
+        return NoContent();
+    }
 }

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -2,9 +2,9 @@ using AdminService.Src.Application.Interfaces;
 using AdminService.src.Application.Mapping;
 using AdminService.Src.Application.Services;
 using AdminService.Src.Domain.Interfaces;
+using AdminService.Src.Infraestructure.Adapters;
 using AdminService.Src.Infraestructure.Data;
 using AdminService.Src.Infraestructure.Repositories;
-using AdminService.Src.Infrastructure.Adapters;
 using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
@@ -42,7 +42,9 @@ builder.Services.AddHttpClient<IEnvironmentServiceAdapter, EnvironmentServiceAda
 builder.Services.AddScoped<DbContext, AppDbContext>();
 builder.Services.AddScoped<ITour360RequestService, Tour360RequestService>();
 builder.Services.AddScoped<ITour360RequestRepository, Tour360RequestRepository>();
+
 builder.Services.AddScoped<IEnvironmentServiceAdapter, EnvironmentServiceAdapter>();
+builder.Services.AddScoped<ITourUploaderAdapter, TourUploaderAdapter>();
 
 builder.Services.AddAutoMapper(typeof(AdminProfile));
 


### PR DESCRIPTION
### What I did:
Implemented a clean endpoint to upload a Virtual Tour for a Tour360Request, following Clean Architecture standards.

---

### How I did it:

- Added UploadTourAsync method to the Tour360RequestService to handle the logic.
- Created and executed UploadTour360Command inside the Service layer.
- Updated the Tour360RequestController to delegate to the Service instead of creating commands directly.
- Ensured that only Admin users can upload Virtual Tours using [Authorize(Roles = "Admin")].

---

### Why I did it:

To maintain a clean separation of concerns, ensure scalability, and correctly link Virtual Tours with their environments through a proper and secure Admin workflow.