### PR TITLE
Feature/spacio 125/tag detected objects in environments

### DIFF
--- a/src/Application/Commands/Concretes/UploadTour360Command.cs
+++ b/src/Application/Commands/Concretes/UploadTour360Command.cs
@@ -1,6 +1,7 @@
 using AdminService.Src.Application.Commands.Interfaces;
 using AdminService.Src.Application.DTOs.Create;
 using AdminService.Src.Application.Interfaces;
+using AdminService.Src.Domain.Enums;
 using AdminService.Src.Domain.Interfaces;
 
 namespace AdminService.Src.Application.Commands.Concretes;
@@ -9,27 +10,32 @@ public class UploadTour360Command(
     Guid tourRequestId,
     TourUploadDto tourUpload,
     ITour360RequestRepository repository,
-    ITourUploaderAdapter tourUploaderAdapter) : ICommand<bool>
+    ITourUploaderAdapter tourUploaderAdapter,
+    IObjectDetectionAdapter objectDetectionAdapter,
+    IEnvironmentServiceAdapter environmentServiceAdapter
+) : ICommand<bool>
 {
     private readonly Guid _tourRequestId = tourRequestId;
     private readonly TourUploadDto _tourUpload = tourUpload;
     private readonly ITour360RequestRepository _repository = repository;
     private readonly ITourUploaderAdapter _tourUploaderAdapter = tourUploaderAdapter;
+    private readonly IObjectDetectionAdapter _objectDetectionAdapter = objectDetectionAdapter;
+    private readonly IEnvironmentServiceAdapter _environmentServiceAdapter = environmentServiceAdapter;
 
     public async Task<bool> ExecuteAsync()
     {
         var tourRequest = await _repository.GetByIdAsync(_tourRequestId)
                           ?? throw new Exception("360 Tour Request Not Found");
 
-        if (tourRequest.Status != Domain.Enums.Tour360Status.Pending &&
-            tourRequest.Status != Domain.Enums.Tour360Status.Scheduled)
+        if (tourRequest.Status != Tour360Status.Pending &&
+            tourRequest.Status != Tour360Status.Scheduled)
         {
             throw new Exception("The Request cannot be Uploaded in Current Status");
         }
 
         await _tourUploaderAdapter.UploadTourAsync(tourRequest.EnvironmentId, _tourUpload);
 
-        tourRequest.Status = Domain.Enums.Tour360Status.Completed;
+        tourRequest.Status = Tour360Status.Completed;
         await _repository.UpdateAsync(tourRequest);
 
         return true;

--- a/src/Application/Commands/Concretes/UploadTour360Command.cs
+++ b/src/Application/Commands/Concretes/UploadTour360Command.cs
@@ -38,6 +38,17 @@ public class UploadTour360Command(
         tourRequest.Status = Tour360Status.Completed;
         await _repository.UpdateAsync(tourRequest);
 
+        var imageUrls = _tourUpload.Scenes
+            .Where(s => !string.IsNullOrWhiteSpace(s.FileUrl))
+            .Select(s => s.FileUrl)
+            .ToList();
+
+        if (imageUrls.Count > 0)
+        {
+            var detectedObjects = await _objectDetectionAdapter.DetectFromImagesAsync(imageUrls);
+            await _environmentServiceAdapter.UpdateDetectedObjectsAsync(tourRequest.EnvironmentId, detectedObjects);
+        }
+
         return true;
     }
 }

--- a/src/Application/DTOs/Response/DetectedObjectResponse.cs
+++ b/src/Application/DTOs/Response/DetectedObjectResponse.cs
@@ -1,0 +1,8 @@
+namespace AdminService.Src.Application.DTOs.Response;
+
+public class DetectedObjectResponse
+{
+    public int Count { get; set; }
+
+    public string Name { get; set; } = string.Empty;
+}

--- a/src/Application/Interfaces/IEnvironmentServiceAdapter.cs
+++ b/src/Application/Interfaces/IEnvironmentServiceAdapter.cs
@@ -5,4 +5,6 @@ namespace AdminService.Src.Application.Interfaces;
 public interface IEnvironmentServiceAdapter
 {
     Task<EnvironmentDetailsResponse?> GetEnvironmentDetailsAsync(Guid environmentPublicId);
+
+    Task UpdateDetectedObjectsAsync(Guid environmentPublicId, Dictionary<string, int> detectedObjects);
 }

--- a/src/Application/Interfaces/IObjectDetectionAdapter.cs
+++ b/src/Application/Interfaces/IObjectDetectionAdapter.cs
@@ -1,0 +1,6 @@
+namespace AdminService.Src.Application.Interfaces;
+
+public interface IObjectDetectionAdapter
+{
+    Task<Dictionary<string, int>> DetectFromImagesAsync(List<string> imageUrls);
+}

--- a/src/Application/Services/Tour360RequestService.cs
+++ b/src/Application/Services/Tour360RequestService.cs
@@ -12,13 +12,15 @@ public class Tour360RequestService(
     ITour360RequestRepository repository,
     IMapper mapper,
     IEnvironmentServiceAdapter environmentServiceAdapter,
-    ITourUploaderAdapter tourUploadAdapter
+    ITourUploaderAdapter tourUploadAdapter,
+    IObjectDetectionAdapter objectDetectionAdapter
     ) : ITour360RequestService
 {
     private readonly ITour360RequestRepository _repository = repository;
     private readonly IMapper _mapper = mapper;
     private readonly IEnvironmentServiceAdapter _environmentServiceAdapter = environmentServiceAdapter;
     private readonly ITourUploaderAdapter _tourUploadAdapter = tourUploadAdapter;
+    private readonly IObjectDetectionAdapter _objectDetectionAdapter = objectDetectionAdapter;
 
     public async Task<Tour360RequestDto> CreateAsync(Tour360RequestCreateDto request, string authenticatedUserId)
     {
@@ -49,7 +51,9 @@ public class Tour360RequestService(
             tourRequestId,
             uploadDto,
             _repository,
-            _tourUploadAdapter);
+            _tourUploadAdapter,
+            _objectDetectionAdapter,
+            _environmentServiceAdapter);
 
         return await command.ExecuteAsync();
     }

--- a/src/Infraestructure/Adapters/EnvironmentServiceAdapter.cs
+++ b/src/Infraestructure/Adapters/EnvironmentServiceAdapter.cs
@@ -9,7 +9,7 @@ public class EnvironmentServiceAdapter(HttpClient httpClient) : IEnvironmentServ
 
     public async Task<EnvironmentDetailsResponse?> GetEnvironmentDetailsAsync(Guid environmentPublicId)
     {
-        var url = $"http://localhost:5150/api/environments/single?publicId={environmentPublicId}";
+        var url = $"/api/environments/single?publicId={environmentPublicId}";
         try
         {
             var response = await _httpClient.GetFromJsonAsync<EnvironmentDetailsResponse>(url);
@@ -19,5 +19,14 @@ public class EnvironmentServiceAdapter(HttpClient httpClient) : IEnvironmentServ
         {
             return null;
         }
+    }
+
+    public async Task UpdateDetectedObjectsAsync(Guid environmentPublicId, Dictionary<string, int> detectedObjects)
+    {
+        var url = $"/api/environments/{environmentPublicId}/detected-objects";
+        var body = new { detectedObjects };
+
+        var response = await _httpClient.PatchAsJsonAsync(url, body);
+        response.EnsureSuccessStatusCode();
     }
 }

--- a/src/Infraestructure/Adapters/ObjectDetectionAdapter.cs
+++ b/src/Infraestructure/Adapters/ObjectDetectionAdapter.cs
@@ -1,3 +1,4 @@
+using AdminService.Src.Application.DTOs.Response;
 using AdminService.Src.Application.Interfaces;
 
 namespace AdminService.Src.Infraestructure.Adapters;
@@ -13,7 +14,9 @@ public class ObjectDetectionAdapter(HttpClient client) : IObjectDetectionAdapter
         var response = await _client.PostAsJsonAsync(requestUrl, imageUrls);
         response.EnsureSuccessStatusCode();
 
-        var result = await response.Content.ReadFromJsonAsync<Dictionary<string, int>>();
-        return result ?? [];
+        var raw = await response.Content.ReadFromJsonAsync<Dictionary<string, DetectedObjectResponse>>();
+
+        return raw?.ToDictionary(kvp => kvp.Key, kvp => kvp.Value.Count)
+               ?? [];
     }
 }

--- a/src/Infraestructure/Adapters/ObjectDetectionAdapter.cs
+++ b/src/Infraestructure/Adapters/ObjectDetectionAdapter.cs
@@ -1,0 +1,19 @@
+using AdminService.Src.Application.Interfaces;
+
+namespace AdminService.Src.Infraestructure.Adapters;
+
+public class ObjectDetectionAdapter(HttpClient client) : IObjectDetectionAdapter
+{
+    private readonly HttpClient _client = client;
+
+    public async Task<Dictionary<string, int>> DetectFromImagesAsync(List<string> imageUrls)
+    {
+        var requestUrl = "/detect/";
+
+        var response = await _client.PostAsJsonAsync(requestUrl, imageUrls);
+        response.EnsureSuccessStatusCode();
+
+        var result = await response.Content.ReadFromJsonAsync<Dictionary<string, int>>();
+        return result ?? [];
+    }
+}

--- a/src/WebApi/Program.cs
+++ b/src/WebApi/Program.cs
@@ -44,7 +44,18 @@ builder.Services.AddScoped<ITour360RequestService, Tour360RequestService>();
 builder.Services.AddScoped<ITour360RequestRepository, Tour360RequestRepository>();
 
 builder.Services.AddScoped<IEnvironmentServiceAdapter, EnvironmentServiceAdapter>();
+builder.Services.AddScoped<IObjectDetectionAdapter, ObjectDetectionAdapter>();
 builder.Services.AddScoped<ITourUploaderAdapter, TourUploaderAdapter>();
+
+builder.Services.AddHttpClient<IEnvironmentServiceAdapter, EnvironmentServiceAdapter>(client =>
+{
+    client.BaseAddress = new Uri("http://localhost:5150");
+});
+
+builder.Services.AddHttpClient<IObjectDetectionAdapter, ObjectDetectionAdapter>(client =>
+{
+    client.BaseAddress = new Uri("http://localhost:5151");
+});
 
 builder.Services.AddAutoMapper(typeof(AdminProfile));
 


### PR DESCRIPTION
### What I did

* Extended the `UploadTour360Command` to trigger object detection after a 360° tour is uploaded.
* Added a new `IObjectDetectionAdapter` to communicate with the external detection service.
* Used `IEnvironmentServiceAdapter` to send the detected object data to the Environment Service.
* Adapted the detection response to only keep object IDs and their counts.

---

### Why I did it

* To automate the process of identifying and storing equipment in environments after a virtual tour is created.
* This reduces the need for manual entry and ensures consistency between detected objects and stored data.

---

### How I did it

* Extracted `FileUrl` values from uploaded tour scenes.
* Called the external detection service with the list of image URLs.
* Transformed the response to a simplified format: `{ objectId: count }`.
* Sent the result to the Environment Service using the existing adapter, updating the `Equipment` field.
* Followed Clean Architecture by keeping logic inside a command and using adapters for external communication.
